### PR TITLE
test: add vitest suite for OPFSWorker

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, promises as fsp, openSync, fstatSync, readSync, writeSync, ftruncateSync, fsyncSync, closeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+function notFound(): any {
+  const err: any = new Error('NotFound');
+  err.name = 'NotFoundError';
+  return err;
+}
+
+function typeMismatch(): any {
+  const err: any = new Error('TypeMismatch');
+  err.name = 'TypeMismatchError';
+  return err;
+}
+
+class NodeSyncAccessHandle {
+  private fd: number;
+  constructor(private filePath: string) {
+    this.fd = openSync(this.filePath, 'r+');
+  }
+  getSize(): number {
+    return fstatSync(this.fd).size;
+  }
+  read(buffer: Uint8Array, opts: { at?: number } = {}): number {
+    return readSync(this.fd, buffer, 0, buffer.length, opts.at ?? 0);
+  }
+  write(buffer: Uint8Array, opts: { at?: number } = {}): number {
+    return writeSync(this.fd, buffer, 0, buffer.length, opts.at ?? 0);
+  }
+  truncate(size: number): void {
+    ftruncateSync(this.fd, size);
+  }
+  flush(): void {
+    fsyncSync(this.fd);
+  }
+  close(): void {
+    closeSync(this.fd);
+  }
+}
+
+class NodeFileHandle {
+  kind = 'file' as const;
+  constructor(public path: string) {}
+  async createSyncAccessHandle(): Promise<NodeSyncAccessHandle> {
+    return new NodeSyncAccessHandle(this.path);
+  }
+  async getFile(): Promise<File> {
+    const data = await fsp.readFile(this.path);
+    const stat = await fsp.stat(this.path);
+    return new File([data], path.basename(this.path), { lastModified: stat.mtimeMs });
+  }
+}
+
+class NodeDirectoryHandle {
+  kind = 'directory' as const;
+  constructor(public path: string) {}
+  async getDirectoryHandle(name: string, opts: { create?: boolean } = {}): Promise<NodeDirectoryHandle> {
+    const dirPath = path.join(this.path, name);
+    try {
+      const stat = await fsp.stat(dirPath);
+      if (!stat.isDirectory()) {
+        throw typeMismatch();
+      }
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        if (opts.create) {
+          await fsp.mkdir(dirPath);
+        } else {
+          throw notFound();
+        }
+      } else {
+        throw err;
+      }
+    }
+    return new NodeDirectoryHandle(dirPath);
+  }
+  async getFileHandle(name: string, opts: { create?: boolean } = {}): Promise<NodeFileHandle> {
+    const filePath = path.join(this.path, name);
+    try {
+      const stat = await fsp.stat(filePath);
+      if (stat.isDirectory()) {
+        throw typeMismatch();
+      }
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        if (opts.create) {
+          await fsp.writeFile(filePath, new Uint8Array());
+        } else {
+          throw notFound();
+        }
+      } else {
+        throw err;
+      }
+    }
+    return new NodeFileHandle(filePath);
+  }
+  async removeEntry(name: string, opts: { recursive?: boolean } = {}): Promise<void> {
+    const target = path.join(this.path, name);
+    try {
+      const stat = await fsp.stat(target);
+      if (stat.isDirectory()) {
+        if (!opts.recursive) {
+          throw typeMismatch();
+        }
+        await fsp.rm(target, { recursive: true, force: true });
+      } else {
+        await fsp.rm(target);
+      }
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        throw notFound();
+      }
+      throw err;
+    }
+  }
+  async *entries(): AsyncIterableIterator<[string, NodeDirectoryHandle | NodeFileHandle]> {
+    const dirents = await fsp.readdir(this.path, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const full = path.join(this.path, dirent.name);
+      yield dirent.isDirectory() ? [dirent.name, new NodeDirectoryHandle(full)] : [dirent.name, new NodeFileHandle(full)];
+    }
+  }
+}
+
+const rootDir = mkdtempSync(path.join(tmpdir(), 'opfs-worker-'));
+
+(globalThis as any).__OPFS_ROOT__ = rootDir;
+(globalThis as any).navigator = {
+  storage: {
+    getDirectory: async () => new NodeDirectoryHandle(rootDir)
+  }
+} as any;
+
+export {}

--- a/test/opfs-worker.test.ts
+++ b/test/opfs-worker.test.ts
@@ -1,0 +1,90 @@
+import { promises as fsp } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { OPFSWorker } from '../src/worker';
+
+const rootDir = (globalThis as any).__OPFS_ROOT__ as string;
+
+describe('OPFSWorker', () => {
+  let fsw: OPFSWorker;
+
+  beforeEach(async () => {
+    await fsp.rm(rootDir, { recursive: true, force: true });
+    await fsp.mkdir(rootDir, { recursive: true });
+    fsw = new OPFSWorker();
+    await fsw.mount('/');
+  });
+
+  afterEach(async () => {
+    await fsw.clear('/');
+  });
+
+  it('writes and reads files', async () => {
+    await fsw.writeFile('/hello.txt', 'world');
+    const content = await fsw.readFile('/hello.txt');
+    expect(content).toBe('world');
+  });
+
+  it('appends to files', async () => {
+    await fsw.writeFile('/append.txt', 'start');
+    await fsw.appendFile('/append.txt', ' end');
+    const content = await fsw.readFile('/append.txt');
+    expect(content).toBe('start end');
+  });
+
+  it('creates directories recursively and lists them', async () => {
+    await fsw.mkdir('/a/b/c', { recursive: true });
+    const list = await fsw.readdir('/a/b', { withFileTypes: true });
+    expect(list.some(e => e.name === 'c' && e.isDirectory)).toBe(true);
+  });
+
+  it('provides file stats and hash', async () => {
+    await fsw.writeFile('/hash.txt', 'data');
+    const stat = await fsw.stat('/hash.txt', { includeHash: true });
+    expect(stat.isFile).toBe(true);
+    expect(stat.size).toBe(4);
+    expect(stat.hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('provides directory stats', async () => {
+    await fsw.mkdir('/dir', { recursive: true });
+    const stat = await fsw.stat('/dir');
+    expect(stat.isDirectory).toBe(true);
+    expect(stat.isFile).toBe(false);
+  });
+
+  it('indexes directory structure', async () => {
+    await fsw.mkdir('/dir', { recursive: true });
+    await fsw.writeFile('/dir/file.txt', '1');
+    const idx = await fsw.index();
+    expect([...idx.keys()].sort()).toEqual(['/', '/dir', '/dir/file.txt']);
+  });
+
+  it('checks path existence', async () => {
+    await fsw.writeFile('/exists.txt', 'hi');
+    expect(await fsw.exists('/exists.txt')).toBe(true);
+    expect(await fsw.exists('/missing.txt')).toBe(false);
+  });
+
+  it('removes files and directories and clears directory', async () => {
+    await fsw.mkdir('/tmpdir', { recursive: true });
+    await fsw.writeFile('/tmpdir/file.txt', 'x');
+    await fsw.remove('/tmpdir/file.txt');
+    expect(await fsw.exists('/tmpdir/file.txt')).toBe(false);
+    await fsw.remove('/tmpdir', { recursive: true });
+    expect(await fsw.exists('/tmpdir')).toBe(false);
+    await fsw.writeFile('/clear.txt', 'y');
+    await fsw.clear('/');
+    expect(await fsw.exists('/clear.txt')).toBe(false);
+  });
+
+  it('syncs external entries and supports cleanBefore', async () => {
+    await fsw.writeFile('/old.txt', 'old');
+    await fsw.sync([
+      ['/new.txt', 'new'],
+      ['relative.txt', 'rel']
+    ], { cleanBefore: true });
+    expect(await fsw.exists('/old.txt')).toBe(false);
+    expect(await fsw.readFile('/new.txt')).toBe('new');
+    expect(await fsw.readFile('/relative.txt')).toBe('rel');
+  });
+});


### PR DESCRIPTION
## Summary
- mock OPFS using temp filesystem for Node-based tests
- add vitest coverage for file, directory and index operations
- extend test coverage to directory stat and sync operations

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688f937b309c832481e534b3abc11dbb