### PR TITLE
feat: add watch API

### DIFF
--- a/.changeset/watch-api.md
+++ b/.changeset/watch-api.md
@@ -1,0 +1,5 @@
+---
+"opfs-worker": minor
+---
+
+add watch/unwatch API with polling-based file system watching

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,9 @@ export interface DirentData {
     isDirectory: boolean;
 }
 
+export interface WatchEvent {
+    path: string;
+    type: 'create' | 'change' | 'delete';
+}
+
 export type * from './worker';


### PR DESCRIPTION
## Summary
- allow mounting with watch callback and global watch interval
- add polling-based `watch`/`unwatch` APIs to monitor file changes
- document and test watch functionality

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688ff4b0716c8324aa64f2cc1837c573